### PR TITLE
reimplement ngettext, fixes for gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,15 +267,22 @@ There is a default implementation that expects exactly 2 plural forms and does n
 
 Substitutions are each passed through a `toToken` function which you can override.
 
-This function infers `{label, name, key, value}` for any given substitution. It also ensures any React element `value` has a valid `key`.
- 
-By overriding it you can change each substitution token. Such as:
-* Change the `label` that appears in validation errors
-* Change the `__name__` that appears in the untranslated `msgid` text.
-* Change the `key` that is assigned to React elements.
-* Change the `value` by injecting props, converting text to elements, etc.
+By overriding it you can change each substitution token.
 
-Validation of the tokens is made following `toToken`. Tokens may only share `name` or `key` where they have the same `value`. 
+All implementations must return the following:
+
+* `label : string` that appears in validation errors
+* `name : string` that serves as placeholder text in the untranslated `msgid` text.
+* `key : string` the hash key of the substitution, if present.
+* `value : *` the value from the substitution.
+
+Validation of the tokens is made following `toToken`. Tokens may only share `name` where they have the same `value`. 
+
+### `finaliseToken : function`
+
+Once substitutions have been made it is possible that the same React element will appear twice.
+
+At minimum, React requires these occurences to have a different `key`. The default implementation will clone these elements with a unique `key` where it is not already set.
 
 ### `splitPlural : function`
 

--- a/README.md
+++ b/README.md
@@ -267,36 +267,38 @@ There is a default implementation that expects exactly 2 plural forms and does n
 
 Substitutions are each passed through a `toToken` function which you can override.
 
-This function infers `{name, key, value}` for any given substitution. It also ensures any React element `value` has a valid `key`.
+This function infers `{label, name, key, value}` for any given substitution. It also ensures any React element `value` has a valid `key`.
  
 By overriding it you can change each substitution token. Such as:
+* Change the `label` that appears in validation errors
 * Change the `__name__` that appears in the untranslated `msgid` text.
 * Change the `key` that is assigned to React elements.
 * Change the `value` by injecting props, converting text to elements, etc.
 
+Validation of the tokens is made following `toToken`. Tokens may only share `name` or `key` where they have the same `value`. 
+
 ### `splitPlural : function`
 
-This merely implements the split of `msgid` for [ngettext](https://linux.die.net/man/3/ngettext).
+This function implements the split of `msgid` for [ngettext](https://linux.die.net/man/3/ngettext).
 
-Here is the default implementation.
+The default implementation is a rudimentary string split: `msgid => msgid.split('|')`.
 
-```javascript
-const splitPlural = msgid => msgid.split('|');
-splitPlural.expect = 2;
-```
+If you require a different delimiter, or escaping of the delimiter, then you will need to provide a custom implementation.
 
-It is clearly rudimentary. It expects exactly 2 plural forms, meaning a single delimiter character in each and every template.
+### `numPlural : Number`
 
-* If you require escaping of the delimiter then you will need to provide a more complex implementation.
+This validates the template splits into the correct number of plural forms.
 
-* If you omit `expect` count there will be no validation (during development) of the number of delimiters in the template string.
+The default value is `2` matches the default `ngettext` implementation. This means that we expect exactly 2 plural forms, meaning a single delimiter character, in each and every template.
+
+Alternatively, set to `0` or `NaN` (or anything else which satisfieds `isNaN`) to inhibit this check.
 
 ## Environment
 
 ### `process.env.NODE_ENV`
 
-The value `"production"` causes error checking to be skipped.
+The value `"production"` causes validation to be skipped.
 
-This presumes that you have had sufficient development time to identify any problems in your specific use-case. There will be no validation of the template or of substitutions.
+This presumes that you have had sufficient development time to identify any problems in your specific use-case. There will be no checking of the substitutions or of the number of plural forms in the template.
 
 Runtime errors may still result.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "String interpolation of translated text and react components",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "NODE_ENV=production babel src --out-dir lib && npm run test",
+    "prepublish": "npm run lint && npm run test && npm run build",
+    "lint": "eslint src/** test/**",
+    "build": "NODE_ENV=production babel src --out-dir lib && npm run test",
     "test": "NODE_ENV=test tape -r babel-register ./test/**/*-spec.js | tap-diff",
     "watch-test": "NODE_ENV=test tape-watch -r babel-register -R tape-bdd ./test/**/*-spec.js | tap-diff"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "String interpolation of translated text and react components",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "npm run lint && npm run test && npm run build",
+    "prepublish": "npm run lint && npm run build",
     "lint": "eslint src/** test/**",
     "build": "NODE_ENV=production babel src --out-dir lib && npm run test",
     "test": "NODE_ENV=test tape -r babel-register ./test/**/*-spec.js | tap-diff",

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,46 @@
 import {defaultToToken, assertTokens} from './token';
 import {getTemplate, makeSubstitutions} from './template';
-import {calculateDelimiters} from './delimited';
+import {defaultSplitPlural, assertPluralForms} from './plurals';
 
 
 /**
  * Gettext as a tagged template string interpolator.
  *
  * For the interpolator, substitutions should be objects with a single key-value pair. The key
- * gives the `key` and `name` for the token and the `value` gives the value.
+ * gives the `key` and `name` for the token and the `value` gives the value. Substitutions with the
+ * same `name` must have `value` or an Error with result.
  *
  * Where all `substitutions` are `string` then a `string` is returned. Otherwise an `Array` is
  * returned. This allows React elements as substitutions. Elements must have an explicit `key` or
  * they will be assigned one automatically.
  *
- * Failure to pass a `translate` function will not result in an error, but no translation will
+ * Failure to pass a `gettext` function will not result in an error, but no translation will
  * occur.
  *
+ * Customisation of the `toToken` function is for advanced users only. Make reference to the source
+ * code.
+ *
+ * @throws Error On substitutions with duplicate `name`
  * @param {function} [gettext] Optional translation function, required for translation to occur
- * @param {function} [toToken] Optional custom token inference function, yeilds {name, key, value}
+ * @param {function} [toToken] Optional custom token inference function, yields {name, key, value}
+ * @param {string} [NODE_ENV] Reserved for testing
  * @returns {function(array, ...string):array|string} Template string interpolator
  */
 export const gettextFactory = ({
   gettext = x => x,
-  toToken = defaultToToken
+  toToken = defaultToToken,
+  NODE_ENV = (process.env || {}).NODE_ENV
 } = {}) => (strings, ...substitutions) => {
+  // get a msgid template with sensible token names
   const tokens = substitutions.map(toToken);
   const {names, values, msgid} = getTemplate(strings, tokens);
-  assertTokens(tokens, `Error in gettext(${msgid})`);
+
+  // validate unless production
+  if (NODE_ENV !== 'production') {
+    assertTokens(tokens, `Error in gettext\`${msgid}\``);
+  }
+
+  // translate and substitute
   const msgstr = gettext(msgid);
   return makeSubstitutions({msgstr, names, values});
 };
@@ -43,58 +57,52 @@ export const gettextFactory = ({
  * gives the `key` and `name` for the token and the `value` gives the value.
  *
  * Singular and plural forms are contained in the same template and delimited by `delimiter`, by
- * default this is the pipe `|` character. The entire template is translated before the singular or
- * plural form is chosen.
+ * default this is the pipe `|` character.
  *
- * Under normal conditions there must be exactly one delimiter in the template. However a custom
- * `choose` method allows any number of delimited forms, and any mapping between factory arguments
- * and the selected form.
+ * The underlying `ngettext` implementation will choose a single form. It is passed the delimited
+ * strings followed by all arguments to the outer function. Validation of arguments is the
+ * concern of `ngettext` and the user must either ensure that the `quantity` is singular or provide
+ * an `ngettext` that performs validation.
  *
  * Where all `substitutions` are `string` then a `string` is returned. Otherwise an `Array` is
  * returned. This allows React elements as substitutions. Elements must have an explicit `key` or
  * they will be assigned one automatically.
  *
- * Failure to pass a `translate` function will not result in an error, but no translation will
- * occur.
+ * Failure to pass a `ngettext` function will not result in an error, but no translation will
+ * occur. This degenerate case supports exactly 2 plural forms which may not suit some developers.
+ * If you need more forms for development then pass a custom `splitPlural` implementation.
  *
+ * Customisation of the `toToken` function is for advanced users only. Make reference to the source
+ * code.
+ *
+ * @throws Error On substitutions with duplicate `name`, or on insufficent plural forms
  * @param {function} [ngettext] Optional translation function, required for translation to occur
  * @param {function} [toToken] Optional custom token inference function, yeilds {name, key, value}
- * @param {string} [delimiter] Optional custom delimiter character
- * @returns {function():function} Factory for a template string interpolator
+ * @param {function} [splitPlural] Optional split string to plural forms, yeilds Array
+ * @param {string} [NODE_ENV] Reserved for testing
+ * @returns {function(quantity:int):function} Factory for a template string interpolator
  */
 export const ngettextFactory = ({
-  ngettext = x => x,
+  ngettext = (s, p, q) => ((typeof q !== 'number') || isNaN(q) || (q === 1) ? s : p),
   toToken = defaultToToken,
-  delimiter = '|'
-} = {}) => {
-  /*
-  const calc = calculateDelimiters(delimiter);
+  splitPlural = defaultSplitPlural,
+  NODE_ENV = (process.env || {}).NODE_ENV
+} = {}) => (...quantity) => (strings, ...substitutions) => {
+  // get a msgid template with sensible token names and split by the delimiter
+  const tokens = substitutions.map(toToken);
+  const {names, values, msgid} = getTemplate(strings, tokens);
+  const msgidForms = splitPlural(msgid);
 
-  return (...quantity) => (strings, ...substitutions) => {
-    // construct a template with name->value tokens
-    const tokens = substitutions.map(toToken);
-    assertTokens(tokens, `Error in ngettext(${msgid})`);
-    const {names, values, msgid} = getTemplate(strings, tokens);
+  // validate
+  if (NODE_ENV !== 'production') {
+    const message = `Error in ngettext(${quantity.map(String).join(', ')})\`${msgid}\``;
+    assertTokens(tokens, message);
+    assertPluralForms(splitPlural.expect, msgidForms.length, message);
+  }
 
-    // translate
-    const msgstr = ngettext(msgid/*, ...TBD*//*);
-
-    // process delimiters
-    const {lengthUntranslated, lengthTranslated, groups} = calc({strings, msgstr, names, values});
-
-    // ensure translation preserves delimiters
-    if (lengthUntranslated !== lengthTranslated) {
-      throw new Error('ngettext : translation must preserve all delimiter characters');
-    } else if (lengthUntranslated < 2) {
-      throw new Error(`ngettext : must contain a delimiter character "${delimiter}"`);
-    }
-
-    // evaluate just the singular or plural
-    const chosen = choose(groups, ...quantity);
-    const {substituted, isText} = makeSubstitutions(chosen);
-    return isText ? substituted.join('') : substituted;
-  };
-  */
+  // translate and make substitutions
+  const msgstr = ngettext(...msgidForms, ...quantity);
+  return makeSubstitutions({msgstr, names, values});
 };
 
 

--- a/src/plurals.js
+++ b/src/plurals.js
@@ -28,11 +28,15 @@ export const calculateDelimiters = delimiter => ({strings, msgstr, names, values
 };
 
 
-export const defaultSplitPlural = msgid => msgid.split('|');
-defaultSplitPlural.expect = 2;
+export const defaultNgettext = (singular, plural, quantity) =>
+  ((typeof quantity !== 'number') || isNaN(quantity) || (quantity === 1) ? singular : plural);
 
 
-export const assertPluralForms = (expected, actual, messagemessage) => {
+export const defaultSplitPlural = msgid =>
+  msgid.split('|');
+
+
+export const assertPluralForms = (expected, actual, message) => {
   if (!isNaN(expected) && (expected > 0) && (actual !== expected)) {
     throw new Error(`${message}: expected ${expected} plural forms, saw ${actual}`);
   }

--- a/src/plurals.js
+++ b/src/plurals.js
@@ -1,41 +1,32 @@
-
-export const calculateDelimiters = delimiter => ({strings, msgstr, names, values}) => {
-  // untranslated
-  const delimIndices = strings
-    .reduce((reduced, v, i) => {
-      const count = v.split(delimiter).length - 1;
-      return reduced.concat((new Array(count)).fill(i));
-    }, []);
-  const lengthUntranslated = delimIndices.length + 1;
-
-  // translated
-  const splitTranslated = msgstr.split(delimiter);
-  const lengthTranslated = splitTranslated.length;
-
-  // collate by delimited text
-  const groups = splitTranslated
-    .map((element, i) => {
-      const start = ((i - 1) in delimIndices) ? delimIndices[i - 1] : 0;
-      const end = (i in delimIndices) ? delimIndices[i] : Number.MAX_SAFE_INTEGER;
-      return {
-        msgid: element,
-        names: names.slice(start, end),
-        values: values.slice(start, end)
-      };
-    });
-
-  return {lengthUntranslated, lengthTranslated, groups};
-};
-
-
+/**
+ * Ngettext implementation that performs no translation.
+ *
+ * @param {string} singular A msgid for when `quantity === 1`
+ * @param {string} plural A msgid for when `quantity !== 1`
+ * @param {number} quantity A quantity that indicates plural
+ * @returns Either the singular or plural msgstr
+ */
 export const defaultNgettext = (singular, plural, quantity) =>
   ((typeof quantity !== 'number') || isNaN(quantity) || (quantity === 1) ? singular : plural);
 
 
+/**
+ * Split template by a delimiter into multiple msgid forms.
+ *
+ * @param {string} msgid The template string to split
+ * @returns {Array.<string>} A number of plural forms of msgid, split by the delimiter
+ */
 export const defaultSplitPlural = msgid =>
   msgid.split('|');
 
 
+/**
+ *
+ * @throws Error on incorrect number of plural forms
+ * @param {number|*} expected Expected number of plural forms, possibly non-numeric where disabled
+ * @param {number} actual Actual number of plural forms found
+ * @param {string} message A title for the error
+ */
 export const assertPluralForms = (expected, actual, message) => {
   if (!isNaN(expected) && (expected > 0) && (actual !== expected)) {
     throw new Error(`${message}: expected ${expected} plural forms, saw ${actual}`);

--- a/src/plurals.js
+++ b/src/plurals.js
@@ -26,3 +26,14 @@ export const calculateDelimiters = delimiter => ({strings, msgstr, names, values
 
   return {lengthUntranslated, lengthTranslated, groups};
 };
+
+
+export const defaultSplitPlural = msgid => msgid.split('|');
+defaultSplitPlural.expect = 2;
+
+
+export const assertPluralForms = (expected, actual, messagemessage) => {
+  if (!isNaN(expected) && (expected > 0) && (actual !== expected)) {
+    throw new Error(`${message}: expected ${expected} plural forms, saw ${actual}`);
+  }
+};

--- a/src/template.js
+++ b/src/template.js
@@ -1,19 +1,30 @@
+/**
+ * Combine the given strings and token names to give a msgid string.
+ *
+ * @param {Array.<string>} strings Template strings as given to the tagged template literal
+ * @param {Array.<{name}>} tokens Tokens that contain a `name` field
+ * @return {string} A msgid that contains `name` placeholders for substitutions
+ */
 export const getTemplate = (strings, tokens) => {
-  const [names, values] = tokens
-    .reduce(([n, v], {name, value}) => (
-      [[...n, name], [...v, value]]
-    ), [[], []]);
+  const names = tokens
+    .reduce((reduced, {name}) => [...reduced, name], []);
 
-  const msgid = strings
+  return strings
     .map((v, i) => ((i < names.length) ? `${v}${names[i]}` : v))
     .join('')
     .replace(/\s{2,}/g, ' ');
-
-  return {names, values, msgid};
 };
 
 
-export const makeSubstitutions = ({msgstr, names, values}) => {
+/**
+ * Make substitutions back into the translated string.
+ *
+ * @param {string} msgstr A translated string that contains token names
+ * @param {Array.<{name, key, value}>} tokens Substitution tokens
+ * @param {function} finaliseToken Transform of token to final value
+ * @return {string|Array} A simple string or an Array of string and complex types
+ */
+export const makeSubstitutions = ({msgstr, tokens, finaliseToken}) => {
   const cast = (v) => {
     switch (typeof v) {
       case 'undefined':
@@ -26,30 +37,38 @@ export const makeSubstitutions = ({msgstr, names, values}) => {
     }
   };
 
-  const substituted = names
-    .reduce((reduced, name, i) => {
-      const completed = reduced.slice(0, -1);
-      const split = (reduced[reduced.length - 1] || '').split(name);
-      const unsplit = split.slice(1).join(name);
-      return [...completed, split[0], i, unsplit];
+  const elements = tokens
+    .reduce((reduced, {name}, i) => {
+      if (name.length) {
+        const completed = reduced.slice(0, -1);
+        const remaining = reduced[reduced.length - 1] || '';
+        const split = remaining.split(name);
+        if (split.length > 1) {
+          const unsplit = split.slice(1).join(name);
+          return [...completed, split[0], i, unsplit];
+        }
+      }
+      return reduced;
     }, [msgstr])
-    .map((v, i) => ((i % 2) ? values[(i - 1) / 2] : v))
     .filter(v => (typeof v !== 'string') || v.length);
 
-  const collapsed = substituted
-    .reduceRight((reduced, v) => {
-      const pending = cast(v);
+  const substituted = elements
+    .reduce((reduced, v) => {
+      const pending = cast(
+        (typeof v === 'number') ? finaliseToken(tokens[v], reduced.length) : v
+      );
       if (reduced.length === 0) {
         return [pending];
       } else {
-        const [last, ...rest] = reduced;
+        const rest = reduced.slice(0, -1);
+        const last = reduced[reduced.length - 1];
         return (typeof pending === 'string') && (typeof last === 'string') ?
-          [`${pending}${last}`, ...rest] :
-          [pending, last, ...rest];
+          [...rest, `${last}${pending}`] :
+          [...rest, last, pending];
       }
     }, []);
 
-  return collapsed.every(v => (typeof v === 'string')) ?
-    collapsed.join('') :
-    collapsed;
+  return substituted.every(v => (typeof v === 'string')) ?
+    substituted.join('') :
+    substituted;
 };

--- a/src/token.js
+++ b/src/token.js
@@ -4,32 +4,47 @@ import {isValidElement, cloneElement} from 'react';
 export const defaultToToken = (candidate, i) => {
   // establish the candidate is valid
   const isObject = !!candidate && (typeof candidate === 'object');
-  const keys = isObject ? Object.keys(candidate) : [];
-  const isValid = (keys.length === 1);
+  const fields = isObject ? Object.keys(candidate) : [];
+  const isValid = (fields.length === 1);
+  const field = isValid && fields[0];
 
-  // determine key and name
-  const key = isValid ? keys[0] : i;
-  const name = isValid ? `__${key}__` : String(candidate);
+  // label is human readable, name is for msgid, key i for React
+  //  names can possibly repeat but it costs us nothing to ensure the label and key are more robust
+  const label = isValid ? `${i}:${field}` : i;
+  const name = isValid ? `__${field}__` : String(candidate);
+  const key = isValid ? `${field}-${i}` : i;
 
   // react elements must have a valid key
-  const pending = isValid ? candidate[key] : candidate;
+  const pending = isValid ? candidate[field] : candidate;
   const value = isValidElement(pending) && !pending.key ?
     cloneElement(pending, {key}) :
     pending;
 
-  return {name, key, value};
+  return {label, name, key, value};
 };
 
 
-export const assertTokens = (tokens, message) => {
-  const errors = tokens
-    .filter((token, i, arr) =>
-      arr.slice(i + 1).some(following =>
-        (following.key === token.key) && (following.value !== token.value)
-      ))
-    .map(token => token.key);
+export const calculateCollisions = tokens =>
+  tokens
+    .map((token, i, arr) => {
+      const collidesWith = arr.slice(i + 1)
+        .map(other => ((other.name === token.name) && (other.value !== token.value) && other))
+        .filter(Boolean);
+      return !!collidesWith.length &&
+        [token].concat(collidesWith)
+          .map(x => x.label)
+          .join(' vs ');
+    })
+    .filter(Boolean)
+    .filter((msg, i, arr) =>
+      !arr.slice(0, i).find(prev => (prev.indexOf(msg) >= 0))
+    );
 
-  if (errors.length) {
-    throw new Error(`${message}: substitution must be unique or have unique key: ${errors}`);
+
+export const assertTokens = (tokens, message) => {
+  const collisions = calculateCollisions(tokens);
+  if (collisions.length) {
+    throw new Error(
+      `${message}: substitution with the same bane must have the same value: ${collisions}`);
   }
 };

--- a/src/token.js
+++ b/src/token.js
@@ -1,5 +1,6 @@
 import {isValidElement, cloneElement} from 'react';
 
+
 export const defaultToToken = (candidate, i) => {
   // establish the candidate is valid
   const isObject = !!candidate && (typeof candidate === 'object');
@@ -18,6 +19,7 @@ export const defaultToToken = (candidate, i) => {
 
   return {name, key, value};
 };
+
 
 export const assertTokens = (tokens, message) => {
   const errors = tokens

--- a/test/assertions-spec.js
+++ b/test/assertions-spec.js
@@ -1,0 +1,53 @@
+import describe from 'tape-bdd';
+import {calculateCollisions} from '../src/token';
+
+describe('token validation', (it) => {
+  it('should allow colliding values', assert =>
+    assert.deepEqual(
+      calculateCollisions([
+        {label: 'a', key: 'x', name: '__a__', value: 10},
+        {label: 'b', key: 'x', name: '__b__', value: 10},
+        {label: 'c', key: 'y', name: '__c__', value: 10},
+        {label: 'd', key: 'z', name: '__c__', value: 10},
+        {label: 'e', key: 'x', name: '__a__', value: 10},
+        {label: 'e', key: 'x', name: '__b__', value: 10},
+        {label: 'e', key: 'y', name: '__c__', value: 10},
+        {label: 'e', key: 'z', name: '__c__', value: 10}
+      ]),
+      []
+    )
+  );
+
+  it('should detect colliding names (same name different value)', assert =>
+    assert.deepEqual(
+      calculateCollisions([
+        {label: 'a', key: 'x', name: '__a__', value: 10},
+        {label: 'b', key: 'y', name: '__a__', value: 11},
+        {label: 'c', key: 'z', name: '__a__', value: 12}
+      ]),
+      ['a vs b vs c']
+    )
+  );
+
+  it('should allow colliding keys (same key different value)', assert =>
+    assert.deepEqual(
+      calculateCollisions([
+        {label: 'a', key: 'x', name: '__a__', value: 10},
+        {label: 'b', key: 'x', name: '__b__', value: 11},
+        {label: 'c', key: 'x', name: '__c__', value: 12}
+      ]),
+      []
+    )
+  );
+
+  it('should allow colliding labels (same label different value)', assert =>
+    assert.deepEqual(
+      calculateCollisions([
+        {label: 'a', key: 'x', name: '__a__', value: 10},
+        {label: 'a', key: 'y', name: '__b__', value: 11},
+        {label: 'a', key: 'z', name: '__c__', value: 12}
+      ]),
+      []
+    )
+  );
+});

--- a/test/gettext-spec.js
+++ b/test/gettext-spec.js
@@ -168,7 +168,7 @@ describe('gettext', (it, describe) => {
       const element = React.createElement('span', {foo: 'bar'});
       const result = template`foo ${{a: element}}`;
 
-      assert.looseEqual(result[1], {...element, key: 'a'});
+      assert.looseEqual(result[1], {...element, key: 'a-0'});
     });
 
     it('should not overwrite element key', (assert) => {

--- a/test/gettext-spec.js
+++ b/test/gettext-spec.js
@@ -34,9 +34,8 @@ describe('gettext', (it, describe) => {
     it('should return string for simple-typed substitutions', parametric(() => {
       const template = gettextFactory();
 
-      return [
-        ...SIMPLE_TYPES.map(v => [template`foo ${v}`, `foo ${v}`])
-      ];
+      return SIMPLE_TYPES
+        .map(v => [template`foo ${v}`, `foo ${v}`]);
     }));
 
     it('should return Array for complex-typed substitutions', parametric(() => {
@@ -166,9 +165,14 @@ describe('gettext', (it, describe) => {
     it('should assign element key where empty', (assert) => {
       const template = gettextFactory();
       const element = React.createElement('span', {foo: 'bar'});
-      const result = template`foo ${{a: element}}`;
 
-      assert.looseEqual(result[1], {...element, key: 'a-0'});
+      assert.deepLooseEqual([
+        template`foo ${{a: element}}`,
+        template`${{b: element}} bar`
+      ], [
+        ['foo ', {...element, key: 'a-1'}],
+        [{...element, key: 'b-0'}, ' bar']
+      ]);
     });
 
     it('should not overwrite element key', (assert) => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,3 @@
-
 export const parametric = casesFactory => (assert) => {
   const cases = casesFactory() || [];
   const [expected, actual] = cases
@@ -8,3 +7,17 @@ export const parametric = casesFactory => (assert) => {
 
   assert.deepEqual(expected, actual);
 };
+
+
+export const pair = list =>
+  list
+    .map((v1, i, arr) => {
+      const j = (i + 1) % arr.length;
+      const v2 = arr[j];
+      return [v1, v2];
+    });
+
+
+export const permute = additional => list =>
+  list
+    .reduce((flattened, v) => [...flattened, ...additional.map(x => [...v, x])], []);

--- a/test/ngettext-spec.js
+++ b/test/ngettext-spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import describe from 'tape-bdd';
 import sinon from 'sinon';
+import {defaultNgettext} from '../src/plurals';
 import {ngettextFactory} from '../src/index';
-import {parametric} from './helpers';
+import {parametric, pair, permute} from './helpers';
 
 const SIMPLE_TYPES = [undefined, '', 'bar', false, true, 12, NaN];
 
@@ -12,9 +13,9 @@ const NON_NUMERIC_TYPES = [undefined, '', 'bar', false, true, null, {}, Symbol('
 
 const createSpy = () => {
   const spy = sinon.spy();
-  const ngettext = (text) => {
-    spy(text);
-    return text;
+  const ngettext = (...args) => {
+    spy(...args);
+    return defaultNgettext(...args);
   };
 
   return {spy, ngettext};
@@ -96,45 +97,56 @@ describe('ngettext', (it, describe) => {
 
     it('should return string for simple-typed substitutions', parametric(() => {
       const template = ngettextFactory();
+      const testSet = permute([1, 2])(pair(SIMPLE_TYPES));
 
-      return [
-        ...SIMPLE_TYPES.map(v => [template(1)`foo ${v}|blit`, `foo ${v}`])
-      ];
+      return testSet.map(([v1, v2, q]) => [
+        template(q)`foo ${v1}|bar ${v2}`,
+        (q === 1) ? `foo ${v1}` : `bar ${v2}`
+      ]);
     }));
 
     it('should return Array for complex-typed substitutions', parametric(() => {
       const template = ngettextFactory();
+      const testSet = permute([1, 2])(pair(COMPLEX_TYPES));
 
-      return COMPLEX_TYPES
-        .map(v => [template(1)`foo ${v}|blit`, ['foo ', v]]);
+      return testSet.map(([v1, v2, q]) => [
+        template(q)`foo ${v1}|bar ${v2}`,
+        (q === 1) ? ['foo ', v1] : ['bar ', v2]
+      ]);
     }));
 
     it('should collapse adjacent string elements', parametric(() => {
       const template = ngettextFactory();
 
       return [
-        [template(1)`1${'2'}3${null}4|blit`, ['123', null, '4']]
+        [template(1)`1${'2'}3${null}4|5${'2'}6${null}7`, ['123', null, '4']],
+        [template(2)`1${'2'}3${null}4|5${'2'}6${null}7`, ['526', null, '7']]
       ];
     }));
 
-    it('should retain whitespace substitutions |blit`(unlike normal literals)', parametric(() => {
+    it('should retain whitespace substitutions (unlike normal literals)', parametric(() => {
       const template = ngettextFactory();
 
       return [
-        [template(1)`${' '}${2}${' '}|blit`, ' 2 ']
+        [template(1)`${' '}${2}${' '}|${' '}${3}${' '}`, ' 2 '],
+        [template(2)`${' '}${2}${' '}|${' '}${3}${' '}`, ' 3 ']
       ];
     }));
 
     it('should substitute before translation', parametric(() => {
       const {spy, ngettext} = createSpy();
       const template = ngettextFactory({ngettext});
+      const testSet = permute([1, 2])(pair([...SIMPLE_TYPES, ...COMPLEX_TYPES]));
 
       // spy is called as a side-effect
-      [...SIMPLE_TYPES, ...COMPLEX_TYPES]
-        .forEach(v => template(1)`foo ${v}|blit`);
+      testSet.forEach(([v1, v2, q]) =>
+        template(q)`foo ${v1}|bar ${v2}`
+      );
 
-      return [...SIMPLE_TYPES, ...COMPLEX_TYPES]
-        .map((v, i) => [spy.getCall(i).args[0], `foo ${String(v)}`]);
+      return testSet.map(([v1, v2, q], i) => [
+        spy.getCall(i).args,
+        [`foo ${String(v1)}`, `bar ${String(v2)}`, q]
+      ]);
     }));
   });
 
@@ -144,32 +156,56 @@ describe('ngettext', (it, describe) => {
       const template = ngettextFactory();
 
       return [
-        ...SIMPLE_TYPES.map(v => [template(1)`foo ${{a: v}}|blit`, `foo ${v}`]),
-        ...COMPLEX_TYPES.map(v => [template(1)`foo ${{a: v}}|blit`, ['foo ', v]])
+        ...permute([1, 2])(pair(SIMPLE_TYPES))
+          .map(([v1, v2, q]) => [
+            template(q)`foo ${{a: v1}}|bar ${{b: v2}}`,
+            (q === 1) ? `foo ${v1}` : `bar ${v2}`
+          ]),
+        ...permute([1, 2])(pair(COMPLEX_TYPES))
+          .map(([v1, v2, q]) => [
+            template(q)`foo ${{a: v1}}|bar ${{b: v2}}`,
+            (q === 1) ? ['foo ', v1] : ['bar ', v2]
+          ]),
       ];
     }));
 
     it('should use the hash key in the translation', parametric(() => {
       const {spy, ngettext} = createSpy();
       const template = ngettextFactory({ngettext});
+      const testSet = permute([1, 2])(pair([...SIMPLE_TYPES, ...COMPLEX_TYPES]));
 
       // spy is called as a side-effect
-      [...SIMPLE_TYPES, ...COMPLEX_TYPES]
-        .forEach(v => template(1)`foo ${{a: v}}|blit`);
+      testSet.forEach(([v1, v2, q]) =>
+        template(q)`foo ${{a: v1}}|bar ${{b: v2}}`
+      );
 
-      return [...SIMPLE_TYPES, ...COMPLEX_TYPES]
-        .map((v, i) => [spy.getCall(i).args[0], 'foo __a__']);
+      return testSet.map(([v1, v2, q], i) => [
+        spy.getCall(i).args,
+        ['foo __a__', 'bar __b__', q]
+      ]);
     }));
 
     it('should not generate empty string elements', parametric(() => {
       const template = ngettextFactory();
+      const testSet = permute([1, 2])(pair(COMPLEX_TYPES));
 
       return [
-        ...COMPLEX_TYPES.map(v => [template(1)`${{a: v}}${{a: v}}${{a: v}}|blit`, [v, v, v]]),
-        ...COMPLEX_TYPES.map(v => [template(1)`a${{a: v}}${{a: v}}${{a: v}}|blit`, ['a', v, v, v]]),
-        ...COMPLEX_TYPES.map(v => [template(1)`${{a: v}}b${{a: v}}${{a: v}}|blit`, [v, 'b', v, v]]),
-        ...COMPLEX_TYPES.map(v => [template(1)`${{a: v}}${{a: v}}c${{a: v}}|blit`, [v, v, 'c', v]]),
-        ...COMPLEX_TYPES.map(v => [template(1)`${{a: v}}${{a: v}}${{a: v}}d|blit`, [v, v, v, 'd']])
+        ...testSet.map(([v1, v2, q]) => [
+          template(q)`${{w: v1}}${{x: v2}}|${{y: v1}}${{z: v2}}`,
+          [v1, v2]
+        ]),
+        ...testSet.map(([v1, v2, q]) => [
+          template(q)`a${{w: v1}}${{x: v2}}|a${{y: v1}}${{z: v2}}`,
+          ['a', v1, v2]
+        ]),
+        ...testSet.map(([v1, v2, q]) => [
+          template(q)`${{w: v1}}b${{x: v2}}|${{y: v1}}b${{z: v2}}`,
+          [v1, 'b', v2]
+        ]),
+        ...testSet.map(([v1, v2, q]) => [
+          template(q)`${{w: v1}}${{x: v2}}c|${{y: v1}}${{z: v2}}c`,
+          [v1, v2, 'c']
+        ])
       ];
     }));
 
@@ -177,7 +213,8 @@ describe('ngettext', (it, describe) => {
       const template = ngettextFactory();
 
       return [
-        [template(1)`1${{a: '2'}}3${{b: null}}4|blit`, ['123', null, '4']]
+        [template(1)`1${{a: '2'}}3${{b: null}}4|5${{a: '2'}}6${{b: null}}7`, ['123', null, '4']],
+        [template(2)`1${{a: '2'}}3${{b: null}}4|5${{a: '2'}}6${{b: null}}7`, ['526', null, '7']]
       ];
     }));
 
@@ -213,7 +250,7 @@ describe('ngettext', (it, describe) => {
     it('should use the hash value', (assert) => {
       const template = ngettextFactory();
       const element = React.createElement('span', {foo: 'bar'});
-      const result = template(1)`foo ${{a: element}}|blit`;
+      const result = template(1)`foo ${{a: element}}|bar ${{b: element}}`;
 
       assert.ok(React.isValidElement(result[1]));
     });
@@ -229,17 +266,27 @@ describe('ngettext', (it, describe) => {
     it('should assign element key where empty', (assert) => {
       const template = ngettextFactory();
       const element = React.createElement('span', {foo: 'bar'});
-      const result = template(1)`foo ${{a: element}}|blit`;
 
-      assert.looseEqual(result[1], {...element, key: 'a-0'});
+      assert.deepLooseEqual([
+        template(1)`foo ${{a: element}}|bar ${{b: element}}`,
+        template(2)`foo ${{a: element}}|${{b: element}} bar`
+      ], [
+        ['foo ', {...element, key: 'a-1'}],
+        [{...element, key: 'b-0'}, ' bar']
+      ]);
     });
 
     it('should not overwrite element key', (assert) => {
       const template = ngettextFactory();
       const element = React.createElement('span', {key: 'baz', foo: 'bar'});
-      const result = template(1)`foo ${{a: element}}|blit`;
 
-      assert.looseEqual(result[1], {...element, key: 'baz'});
+      assert.deepLooseEqual([
+        template(1)`foo ${{a: element}}|bar ${{b: element}}`,
+        template(2)`foo ${{a: element}}|${{b: element}} bar`
+      ], [
+        ['foo ', {...element, key: 'baz'}],
+        [{...element, key: 'baz'}, ' bar']
+      ]);
     });
   });
 });

--- a/test/ngettext-spec.js
+++ b/test/ngettext-spec.js
@@ -50,10 +50,7 @@ describe('ngettext', (it, describe) => {
   });
 
   describe('plural forms', (it) => {
-    const splitPlural = msgid => msgid.split('|');
-    splitPlural.expect = 3;
-
-    const ngettext = (s, p1, p2, q) => {
+    const ngettext3 = (s, p1, p2, q) => {
       switch (true) {
         case (typeof q !== 'number'):
         case isNaN(q):
@@ -67,7 +64,10 @@ describe('ngettext', (it, describe) => {
     };
 
     it('should support multiple forms', parametric(() => {
-      const template = ngettextFactory({splitPlural, ngettext});
+      const template = ngettextFactory({
+        numPlural: 3,
+        ngettext: ngettext3
+      });
 
       return [
         [template()`singular|plural1|plural2`, 'singular'],
@@ -82,7 +82,10 @@ describe('ngettext', (it, describe) => {
     }));
 
     it('should throw on new delimiter count mismatch', (assert) => {
-      const template = ngettextFactory({splitPlural, ngettext});
+      const template = ngettextFactory({
+        numPlural: 3,
+        ngettext: ngettext3
+      });
 
       assert.throws(() => template()`foo|bar`);
     });
@@ -228,7 +231,7 @@ describe('ngettext', (it, describe) => {
       const element = React.createElement('span', {foo: 'bar'});
       const result = template(1)`foo ${{a: element}}|blit`;
 
-      assert.looseEqual(result[1], {...element, key: 'a'});
+      assert.looseEqual(result[1], {...element, key: 'a-0'});
     });
 
     it('should not overwrite element key', (assert) => {


### PR DESCRIPTION
I am proposing that we:
* merge this implementation
* Release some patch (?) that is < `1.0.0`
* Confirm it is good for our use-case
* Release a `1.0.0`

We could do an `npm link` if we want to be certain but I think this is a good increment either way.