### PR TITLE
validate arguments to ngettext

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,13 @@
 {
   "extends": "airbnb",
   "rules": {
+    "no-multiple-empty-lines": ["error", {"max": 1}],
     "no-else-return": "off",
     "object-curly-spacing": "off",
     "comma-dangle": "off",
     "import/prefer-default-export": "off",
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
-    "no-shadow": ["error", { "allow": ["describe", "it"] }],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+    "no-shadow": ["error", {"allow": ["describe", "it"]}],
     "padded-blocks": "off",
     "no-mixed-operators": "off",
     "no-nested-ternary": "off",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+
+node_js:
+  - 6
+  - 7
+  - 8
+
+install:
+ - npm install
+
+script:
+  - npm run lint
+  - npm test

--- a/example/misuse.js
+++ b/example/misuse.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The user of ngettext forgets to invoke the function before using the template literal.
+ * DO NOT DO THIS!
+ */
+export const IncorrectUse = ({ngettext, num}) => (
+  <span>
+    {ngettext`We forgot to invoke ngettext() function|with the quantity of ${{num}}`}
+  </span>
+);
+IncorrectUse.propTypes = {
+  ngettext: PropTypes.func.isRequired,
+  num: PropTypes.number.isRequired
+};
+
+/**
+ * The user of ngettext remembers to invoke the function before using the template literal.
+ */
+export const CorrectUse = ({ngettext, num}) => (
+  <span>
+    {ngettext(num)`We remembered to invoke ngettext() function|with the quantity of ${{num}}`}
+  </span>
+);
+CorrectUse.propTypes = {
+  ngettext: PropTypes.func.isRequired,
+  num: PropTypes.number.isRequired
+};

--- a/example/pagination-control.js
+++ b/example/pagination-control.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-
 /**
  * This portion leads to underlying translation
  * 4. msgid  "one more"
@@ -16,7 +15,6 @@ More.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
-
 /**
  * This portion leads to underlying translation
  * 5. msgid  "one less"
@@ -30,7 +28,6 @@ Less.propTypes = {
   num: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired
 };
-
 
 /**
  * Pagination control for progressively expanding to more items or then contract to fewer.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "String interpolation of translated text and react components",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "npm run lint && npm run build",
+    "prepublish": "npm run lint && npm run build && npm run test-build",
     "lint": "eslint src/** test/**",
-    "build": "NODE_ENV=production babel src --out-dir lib && npm run test",
-    "test": "NODE_ENV=test TIMES=50 tape -r babel-register ./test/**/*-spec.js | tap-diff",
-    "watch-test": "NODE_ENV=test tape-watch -r babel-register ./test/**/*-spec.js | tap-diff"
+    "build": "NODE_ENV=production babel src --out-dir lib",
+    "watch-test": "NODE_ENV=test SRC=src tape-watch -r babel-register test/**/*-spec.js | tap-diff",
+    "test": "NODE_ENV=test SRC=src TIMES=50 tape -r babel-register test/**/*-spec.js | tap-diff",
+    "test-build": "NODE_ENV=test SRC=lib TIMES=50 tape -r babel-register test/**/*-spec.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "npm run lint && npm run build && npm run test-build",
-    "lint": "eslint src/** test/**",
+    "lint": "eslint src/** test/** example/**",
     "build": "NODE_ENV=production babel src --out-dir lib",
     "watch-test": "NODE_ENV=test SRC=src tape-watch -r babel-register test/**/*-spec.js | tap-diff",
     "test": "NODE_ENV=test SRC=src TIMES=50 tape -r babel-register test/**/*-spec.js | tap-diff",

--- a/src/assert.js
+++ b/src/assert.js
@@ -1,6 +1,5 @@
 import {calculateErrors, calculateCollisions} from './token';
 
-
 /**
  * Throw where the object[field] is not a function.
  *
@@ -17,7 +16,6 @@ export const assertGettextInstance = (obj, field, message) => {
   }
 };
 
-
 /**
  * Throws where the candidate is not an integer.
  *
@@ -32,7 +30,6 @@ export const assertQuantity = (candidate, message) => {
   }
 };
 
-
 /**
  * Throws where the candidate is not an empty list.
  *
@@ -46,7 +43,6 @@ export const assertUnexpected = (candidate, message) => {
     throw new Error(`${message}: Expected no additional arguments`);
   }
 };
-
 
 /**
  * Throw on token problems.
@@ -67,7 +63,6 @@ export const assertTokens = (tokens, message) => {
       `${message}: substitution with the same name must have the same value: ${collisions}`);
   }
 };
-
 
 /**
  * Throw on incorrect number of plural forms.

--- a/src/assert.js
+++ b/src/assert.js
@@ -19,6 +19,36 @@ export const assertGettextInstance = (obj, field, message) => {
 
 
 /**
+ * Throws where the candidate is not an integer.
+ *
+ * @throws Error on non integer
+ * @param {*} candidate Possible integer
+ * @param {string} message A title for the error
+ */
+export const assertQuantity = (candidate, message) => {
+  const isValid = (typeof candidate === 'number') && !isNaN(candidate) && (candidate % 1 === 0);
+  if (!isValid) {
+    throw new Error(`${message}: Expected an integer quantity`);
+  }
+};
+
+
+/**
+ * Throws where the candidate is not an empty list.
+ *
+ * @throws Error on non-empty list
+ * @param {Array} candidate List of additional arguments
+ * @param {string} message A title for the error
+ */
+export const assertUnexpected = (candidate, message) => {
+  const isValid = Array.isArray(candidate) && (candidate.length === 0);
+  if (!isValid) {
+    throw new Error(`${message}: Expected no additional arguments`);
+  }
+};
+
+
+/**
  * Throw on token problems.
  *
  * @throws Error on token problems

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,7 +6,6 @@
  */
 export const defaultGettext = msgid => msgid;
 
-
 /**
  * Ngettext implementation that performs no translation.
  *
@@ -17,7 +16,6 @@ export const defaultGettext = msgid => msgid;
  */
 export const defaultNgettext = (singular, plural, quantity) =>
   ((typeof quantity !== 'number') || isNaN(quantity) || (quantity === 1) ? singular : plural);
-
 
 /**
  * Split template by a delimiter into multiple msgid forms.

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import {
   assertGettextInstance, assertQuantity, assertUnexpected, assertTokens, assertPluralForms
 } from './assert';
 
-
 /**
  * Gettext as a tagged template string interpolator.
  *
@@ -53,7 +52,6 @@ export const gettextFactory = ({
   const msgstr = gettext.gettext(msgid);
   return makeSubstitutions({msgstr, tokens, finaliseToken});
 };
-
 
 /**
  * NGettext as a tagged template string interpolator.
@@ -133,7 +131,6 @@ export const ngettextFactory = ({
   };
 };
 
-
 /**
  * Create a hash of all methods using shared options.
  *
@@ -146,13 +143,11 @@ export const factory = options => ({
   ngettext: ngettextFactory(options)
 });
 
-
 /**
  * Gettext as a degenerate template string interpolator.
  * @type {*}
  */
 export const gettextDefault = gettextFactory();
-
 
 /**
  * NGettext as a degenerate template string interpolator.

--- a/src/template.js
+++ b/src/template.js
@@ -14,7 +14,6 @@ export const getTemplate = (strings, tokens) => {
     .join('');
 };
 
-
 /**
  * Make substitutions back into the translated string.
  *

--- a/src/token.js
+++ b/src/token.js
@@ -1,6 +1,5 @@
 import {isValidElement, cloneElement} from 'react';
 
-
 /**
  * Convert a substitution into a record.
  *
@@ -40,7 +39,6 @@ export const defaultToToken = (candidate, i) => {
   return {error, label, name, key, value};
 };
 
-
 /**
  * Convert a token into a final substitution value.
  *
@@ -56,7 +54,6 @@ export const defaultFinaliseToken = ({key, value}, i) =>
     cloneElement(value, {key: `${key}-${i}`}) :
     value);
 
-
 /**
  * Calculate a message for those tokens which indicated an error.
  *
@@ -68,7 +65,6 @@ export const calculateErrors = tokens =>
     .map(({error}) => error)
     .filter(Boolean)
     .filter((v, i, a) => (a.indexOf(v) === i));
-
 
 /**
  * Calculate a message for those tokens with a name collision.

--- a/test/example-spec.js
+++ b/test/example-spec.js
@@ -2,12 +2,13 @@ import test from 'tape';
 import 'raf/polyfill';
 import 'jsdom-global/register';
 import React from 'react';
-import {mount, configure} from 'enzyme';
+import {mount, shallow, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import {gettextDefault, ngettextDefault} from '../src/index';
 import {StrongText, AnchorText} from '../example/simple-inline';
 import {PaginationControl} from '../example/pagination-control';
+import {IncorrectUse, CorrectUse} from '../example/misuse';
 
 configure({adapter: new Adapter()});
 
@@ -98,6 +99,25 @@ test('example: pagination-control', (t) => {
     ).html(),
     '<div>Show <a href="">5 less</a></div>',
     'maximal case should render correctly'
+  );
+
+  t.end();
+});
+
+test('example: misuse', (t) => {
+  t.throws(
+    () => shallow(
+      <IncorrectUse ngettext={ngettextDefault} num={10} />
+    ),
+    /Expected an integer quantity/,
+    'ngettext misuse should throw error'
+  );
+
+  t.doesNotThrow(
+    () => shallow(
+      <CorrectUse ngettext={ngettextDefault} num={10} />
+    ),
+    'ngettext correct use should not throw error'
   );
 
   t.end();

--- a/test/example-spec.js
+++ b/test/example-spec.js
@@ -5,10 +5,12 @@ import React from 'react';
 import {mount, shallow, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import {gettextDefault, ngettextDefault} from '../src/index';
+import {requireSrc} from './helpers';
 import {StrongText, AnchorText} from '../example/simple-inline';
 import {PaginationControl} from '../example/pagination-control';
 import {IncorrectUse, CorrectUse} from '../example/misuse';
+
+const {gettextDefault, ngettextDefault} = requireSrc('index');
 
 configure({adapter: new Adapter()});
 

--- a/test/generators.js
+++ b/test/generators.js
@@ -1,12 +1,10 @@
 import {gen} from 'tape-check';
 
-
 // testcheck has problems with uniqueness of undefined and null
 const undef = {};
 const nul = {};
 const uniqueFn = v =>
   ((v === undefined) ? undef : (v === null) ? nul : v);
-
 
 // exclude the default ngettext delimiter, subtitute it at your own peril
 export const anyPrimitive = gen.primitive
@@ -43,7 +41,6 @@ export const anyEnumerableWithMultipleKeys = gen.object({
   y: anyValue
 });
 
-
 /**
  * The set of values that don't have valid keys and are considered non-primitive
  * @type {Generator<any>}
@@ -55,7 +52,6 @@ export const anyUnkeyedComplexSubstitution = gen.oneOf([
   anyEnumerableWithMultipleKeys
 ]);
 
-
 /**
  * key-value pair of a single primitive value with a valid key
  * @type {Generator<any>}
@@ -64,7 +60,6 @@ export const anyKeyedPrimitiveSubstitutionKV = gen.object({
   k: anyNonEmptyAlphaNumericString,
   v: anyPrimitive
 });
-
 
 /**
  * key-value pair of a single non-primitive value with a valid key
@@ -75,7 +70,6 @@ export const anyKeyedComplexSubstitutionKV = gen.object({
   v: gen.oneOf([anySymbolOrFunctionRef, anyEmptyObjectOrArray])
 });
 
-
 /**
  * key-value pair of a single primitive value with an invalid key
  * @type {Generator<any>}
@@ -84,7 +78,6 @@ export const anyIllegalPrimitiveSubstitutionKV = gen.object({
   k: anyIllegalString.notEmpty(),
   v: anyPrimitive
 });
-
 
 /**
  * key-value pair of a single non-primitive value with an invalid key
@@ -95,14 +88,12 @@ export const anyIllegalComplexSubstitutionKV = gen.object({
   v: gen.oneOf([anySymbolOrFunctionRef, anyEmptyObjectOrArray])
 });
 
-
 /**
  * The set of substitutions which we expect to remain as separate elements in the final result
  * @type {Generator<any>}
  */
 export const anyObjectLikeSubstitution = anyKeyedComplexSubstitutionKV
   .then(({k, v}) => ({[k]: v}));
-
 
 /**
  * The set of substitutions which we expect to become strings in the final result
@@ -113,7 +104,6 @@ export const anyStringLikeSubstitution = gen.oneOf([
   anyUnkeyedComplexSubstitution,
   anyKeyedPrimitiveSubstitutionKV.then(({k, v}) => ({[k]: v}))
 ]);
-
 
 // pre-generate all the necessary elements to ensure they are unique
 const genUniqueTokens = ({minSize, maxSize}) =>
@@ -174,7 +164,6 @@ const createDuplicatesIn = field => ({uniqueTokens, groupedIndices, ...rest}) =>
   })
 });
 
-
 /**
  * Generator for between 2 and 9 tokens with some conflicting values.
  *
@@ -187,7 +176,6 @@ export const genTokensWithDuplicateValues =
   genUniqueTokens({minSize: 2, maxSize: 9})
     .then(genGroupedIndicesForTokens({maxGroups: 3}))
     .then(createDuplicatesIn('value'));
-
 
 /**
  * Generator for between 2 and 9 tokens with some conflicting names.
@@ -209,7 +197,6 @@ export const genTokensWithDuplicateNames =
         .map(({label}) => label)
       )
     }));
-
 
 /**
  * Generate a number of substitution values which might imply objects or strings in the final

--- a/test/gettext-spec.js
+++ b/test/gettext-spec.js
@@ -95,7 +95,7 @@ test('gettext: direct complex substitution', check(
 
     t.throws(
       () => devTemplate`foo ${v}`,
-      /Error in gettext/,
+      /All non-primitive substitutions must be "keyed"/,
       'should throw error in development env'
     );
     t.notOk(
@@ -156,7 +156,7 @@ test('gettext: illegally keyed primitive substitution', check(
 
     t.throws(
       () => devTemplate`foo ${{[k]: v}}`,
-      /Error in gettext/,
+      /Keys must be alphanumeric/,
       'should throw error in development env'
     );
     t.notOk(
@@ -217,7 +217,7 @@ test('gettext: illegally keyed complex substitution', check(
 
     t.throws(
       () => devTemplate`foo ${{[k]: v}}`,
-      /Error in gettext/,
+      /Keys must be alphanumeric/,
       'should throw error in development env'
     );
     t.notOk(
@@ -278,7 +278,7 @@ test('gettext: keyed substitution with duplicate names', check(
 
     t.throws(
       () => devTemplate(strings, ...tokens),
-      /Error in gettext/,
+      /All non-primitive substitutions must be "keyed"/,
       'should throw error in development env'
     );
     t.notOk(

--- a/test/gettext-spec.js
+++ b/test/gettext-spec.js
@@ -14,7 +14,6 @@ import {
 const {defaultGettext} = requireSrc('defaults');
 const {gettextFactory} = requireSrc('index');
 
-
 const createSpy = () => {
   const spy = sinon.spy();
   const gettext = (...args) => {
@@ -24,7 +23,6 @@ const createSpy = () => {
 
   return {spy, gettext: {gettext}};
 };
-
 
 test('gettext: created with bad gettext instance', (t) => {
   const devTemplate = gettextFactory({NODE_ENV: 'development', gettext: {}});
@@ -46,7 +44,6 @@ test('gettext: created with bad gettext instance', (t) => {
   t.end();
 });
 
-
 test('gettext: degenerate case without substitutions', (t) => {
   const {spy, gettext} = createSpy();
   const template = gettextFactory({gettext});
@@ -63,7 +60,6 @@ test('gettext: degenerate case without substitutions', (t) => {
   );
   t.end();
 });
-
 
 test('gettext: direct primitive substitution', check(
   times(20),
@@ -85,7 +81,6 @@ test('gettext: direct primitive substitution', check(
     t.end();
   }
 ));
-
 
 test('gettext: direct complex substitution', check(
   times(20),
@@ -125,7 +120,6 @@ test('gettext: direct complex substitution', check(
   }
 ));
 
-
 test('gettext: keyed primitive substitution', check(
   times(20),
   anyKeyedPrimitiveSubstitutionKV,
@@ -146,7 +140,6 @@ test('gettext: keyed primitive substitution', check(
     t.end();
   }
 ));
-
 
 test('gettext: illegally keyed primitive substitution', check(
   times(10),
@@ -186,7 +179,6 @@ test('gettext: illegally keyed primitive substitution', check(
   }
 ));
 
-
 test('gettext: keyed complex substitution', check(
   times(20),
   anyKeyedComplexSubstitutionKV,
@@ -207,7 +199,6 @@ test('gettext: keyed complex substitution', check(
     t.end();
   }
 ));
-
 
 test('gettext: illegally keyed complex substitution', check(
   times(10),
@@ -247,7 +238,6 @@ test('gettext: illegally keyed complex substitution', check(
   }
 ));
 
-
 test('gettext: mix of keyed and non-keyed substitutions', check(
   times(20),
   genMixOfStringAndObjectSubstitutions({size: 3}),
@@ -267,7 +257,6 @@ test('gettext: mix of keyed and non-keyed substitutions', check(
     t.end();
   }
 ));
-
 
 test('gettext: keyed substitution with duplicate names', check(
   times(20),
@@ -296,7 +285,6 @@ test('gettext: keyed substitution with duplicate names', check(
     t.end();
   }
 ));
-
 
 test('gettext: keyed React element substitution', (t) => {
   const template = gettextFactory();

--- a/test/gettext-spec.js
+++ b/test/gettext-spec.js
@@ -3,15 +3,16 @@ import sinon from 'sinon';
 import React from 'react';
 import {check} from 'tape-check';
 
-import {times} from './helpers';
+import {times, requireSrc} from './helpers';
 import {
   anyPrimitive, anyUnkeyedComplexSubstitution,
   anyKeyedPrimitiveSubstitutionKV, anyKeyedComplexSubstitutionKV,
   anyIllegalPrimitiveSubstitutionKV, anyIllegalComplexSubstitutionKV,
   genTokensWithDuplicateNames, genMixOfStringAndObjectSubstitutions
 } from './generators';
-import {defaultGettext} from '../src/defaults';
-import {gettextFactory} from '../src/index';
+
+const {defaultGettext} = requireSrc('defaults');
+const {gettextFactory} = requireSrc('index');
 
 
 const createSpy = () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,11 @@
+import path from 'path';
+
 export const times = minimum => ({
   times: minimum * (parseInt(process.env.TIMES, 10) || 1.0)
 });
 
 export const safeIsNaN = v =>
   ((typeof v === 'number') && isNaN(v));
+
+export const requireSrc = filename =>
+  require(path.join('..', process.env.SRC, filename)); // eslint-disable-line global-require, import/no-dynamic-require

--- a/test/ngettext-spec.js
+++ b/test/ngettext-spec.js
@@ -14,7 +14,6 @@ import {
 const {defaultNgettext} = requireSrc('defaults');
 const {ngettextFactory} = requireSrc('index');
 
-
 const createSpy = () => {
   const spy = sinon.spy();
   const ngettext = (...args) => {
@@ -24,7 +23,6 @@ const createSpy = () => {
 
   return {spy, gettext: {ngettext}};
 };
-
 
 test('gettext: created with bad gettext instance', (t) => {
   const devTemplate = ngettextFactory({NODE_ENV: 'development', gettext: {}});
@@ -45,7 +43,6 @@ test('gettext: created with bad gettext instance', (t) => {
 
   t.end();
 });
-
 
 const genMismatchedTemplateStrings = ({numForms}) =>
   gen.posInt
@@ -91,7 +88,6 @@ test('ngettext: mismatched template and number of plural forms', check(
   }
 ));
 
-
 test('ngettext: non-integer invocation', check(
   times(5),
   gen.oneOf([
@@ -127,7 +123,6 @@ test('ngettext: non-integer invocation', check(
     t.end();
   }
 ));
-
 
 test('ngettext: invoked with additional arguments', check(
   times(5),
@@ -165,7 +160,6 @@ test('ngettext: invoked with additional arguments', check(
   }
 ));
 
-
 test('ngettext: degenerate case without substitutions', check(
   times(5),
   gen.posInt,
@@ -186,7 +180,6 @@ test('ngettext: degenerate case without substitutions', check(
     t.end();
   }
 ));
-
 
 test('ngettext: direct primitive substitution', check(
   times(20),
@@ -209,7 +202,6 @@ test('ngettext: direct primitive substitution', check(
     t.end();
   }
 ));
-
 
 test('ngettext: direct complex substitution', check(
   times(20),
@@ -250,7 +242,6 @@ test('ngettext: direct complex substitution', check(
   }
 ));
 
-
 test('ngettext: keyed primitive substitution', check(
   times(20),
   gen.posInt,
@@ -272,7 +263,6 @@ test('ngettext: keyed primitive substitution', check(
     t.end();
   }
 ));
-
 
 test('ngettext: illegally keyed primitive substitution', check(
   times(10),
@@ -313,7 +303,6 @@ test('ngettext: illegally keyed primitive substitution', check(
   }
 ));
 
-
 test('ngettext: keyed complex substitution', check(
   times(20),
   gen.posInt,
@@ -335,7 +324,6 @@ test('ngettext: keyed complex substitution', check(
     t.end();
   }
 ));
-
 
 test('ngettext: illegally keyed complex substitution', check(
   times(10),
@@ -376,7 +364,6 @@ test('ngettext: illegally keyed complex substitution', check(
   }
 ));
 
-
 test('ngettext: mix of keyed and non-keyed substitutions', check(
   times(20),
   gen.posInt,
@@ -397,7 +384,6 @@ test('ngettext: mix of keyed and non-keyed substitutions', check(
     t.end();
   }
 ));
-
 
 test('ngettext: keyed substitution with duplicate names', check(
   times(20),
@@ -427,7 +413,6 @@ test('ngettext: keyed substitution with duplicate names', check(
     t.end();
   }
 ));
-
 
 test('ngettext: keyed React element substitution', (t) => {
   const template = ngettextFactory();

--- a/test/ngettext-spec.js
+++ b/test/ngettext-spec.js
@@ -92,7 +92,7 @@ test('ngettext: non-integer invocation', check(
   times(5),
   gen.oneOf([
     anyValue.suchThat(v => (typeof v !== 'number')),
-    gen.number.notEmpty().suchThat(v => (v % 1 !== 0)), /* avoid integers and NaN */
+    gen.numberWithin(-100, 100).suchThat(v => (v % 1 !== 0)), /* avoid integers and NaN */
   ]),
   (t, n) => {
     const {spy, gettext} = createSpy();

--- a/test/ngettext-spec.js
+++ b/test/ngettext-spec.js
@@ -3,15 +3,16 @@ import sinon from 'sinon';
 import React from 'react';
 import {check, gen} from 'tape-check';
 
-import {times} from './helpers';
+import {times, requireSrc} from './helpers';
 import {
   anyPrimitive, anyValue, anyUnkeyedComplexSubstitution,
   anyKeyedPrimitiveSubstitutionKV, anyKeyedComplexSubstitutionKV,
   anyIllegalPrimitiveSubstitutionKV, anyIllegalComplexSubstitutionKV,
   genTokensWithDuplicateNames, genMixOfStringAndObjectSubstitutions
 } from './generators';
-import {defaultNgettext} from '../src/defaults';
-import {ngettextFactory} from '../src/index';
+
+const {defaultNgettext} = requireSrc('defaults');
+const {ngettextFactory} = requireSrc('index');
 
 
 const createSpy = () => {

--- a/test/token-spec.js
+++ b/test/token-spec.js
@@ -1,14 +1,14 @@
 import test from 'tape';
 import {check, gen} from 'tape-check';
 
-import {times, safeIsNaN} from './helpers';
+import {times, safeIsNaN, requireSrc} from './helpers';
 import {
   anyValue, anyNonEmptyAlphaNumericString,
   anyEnumerableInvalidKey, anyEnumerableWithMultipleKeys,
   genTokensWithDuplicateValues, genTokensWithDuplicateNames
 } from './generators';
 
-import {defaultToToken, calculateCollisions} from '../src/token';
+const {defaultToToken, calculateCollisions} = requireSrc('token');
 
 
 test('token parsing: direct substitutions or invalid keyed substitutions', check(

--- a/test/token-spec.js
+++ b/test/token-spec.js
@@ -10,7 +10,6 @@ import {
 
 const {defaultToToken, calculateCollisions} = requireSrc('token');
 
-
 test('token parsing: direct substitutions or invalid keyed substitutions', check(
   times(50),
   gen.oneOfWeighted([
@@ -29,7 +28,6 @@ test('token parsing: direct substitutions or invalid keyed substitutions', check
     t.end();
   }
 ));
-
 
 test('token parsing: valid keyed substitutions', check(
   times(50),
@@ -54,7 +52,6 @@ test('token parsing: valid keyed substitutions', check(
   }
 ));
 
-
 test('token validation: duplicate values', check(
   times(50),
   genTokensWithDuplicateValues,
@@ -67,7 +64,6 @@ test('token validation: duplicate values', check(
     t.end();
   }
 ));
-
 
 test('token validation: duplicate names', check(
   times(50),


### PR DESCRIPTION
Addresses #7 and #8.

Changes
* Validate arguments to `ngettext`.
    * Need 2 stages of validation, one for outer closure and another for the inner template.
    * Reusable per `assert.js`, since we anticipate more API methods in the future.
    * Additional tests
* Streamline the error messages in both `gettext` and `ngettext`. Be more specific in the tests.
